### PR TITLE
Added support for Niladic functions.

### DIFF
--- a/CodeFirstStoreFunctions/DbFunctionDetailsAttribute.cs
+++ b/CodeFirstStoreFunctions/DbFunctionDetailsAttribute.cs
@@ -8,6 +8,7 @@ namespace CodeFirstStoreFunctions
     public class DbFunctionDetailsAttribute : Attribute
     {
         private bool _isBuiltIn;
+        private bool _isNiladic;
 
         /// <summary>
         /// Gets or sets the name of the database schema of the store function.
@@ -23,6 +24,23 @@ namespace CodeFirstStoreFunctions
         /// Gets or sets the types returned by a function mapped to a stored procedure returning multuple resultsets.
         /// </summary>
         public Type[] ResultTypes { get; set; }
+
+        /// <summary>
+        /// Gets or sets whether the function is a niladic function.
+        /// </summary>
+        public bool IsNiladic
+        {
+            get
+            {
+                return _isNiladic;
+            }
+
+            set
+            {
+                _isNiladic = value;
+                IsNiladicPropertySet = true;
+            }
+        }
 
         /// <summary>
         /// Gets or sets whether the function is a built in function.
@@ -42,5 +60,6 @@ namespace CodeFirstStoreFunctions
         }
 
         internal bool IsBuiltInPropertySet { get; private set; }
+        internal bool IsNiladicPropertySet { get; private set; }
     }
 }

--- a/CodeFirstStoreFunctions/FunctionDescriptor.cs
+++ b/CodeFirstStoreFunctions/FunctionDescriptor.cs
@@ -16,9 +16,10 @@ namespace CodeFirstStoreFunctions
         private readonly string _databaseSchema;
         private readonly StoreFunctionKind _storeFunctionKind;
         private readonly bool? _isBuiltIn;
+        private readonly bool? _isNiladic;
 
         public FunctionDescriptor(string name, IEnumerable<ParameterDescriptor> parameters,
-            EdmType[] returnTypes, string resultColumnName, string databaseSchema, StoreFunctionKind storeFunctionKind, bool? isBuiltIn)
+            EdmType[] returnTypes, string resultColumnName, string databaseSchema, StoreFunctionKind storeFunctionKind, bool? isBuiltIn, bool? isNiladic)
       {
             Debug.Assert(!string.IsNullOrWhiteSpace(name), "invalid name");
             Debug.Assert(parameters != null, "parameters is null");
@@ -33,7 +34,8 @@ namespace CodeFirstStoreFunctions
             _databaseSchema = databaseSchema;
             _storeFunctionKind = storeFunctionKind;
             _isBuiltIn = isBuiltIn;
-        }
+            _isNiladic = isNiladic;
+      }
 
         public string Name
         {
@@ -68,6 +70,11 @@ namespace CodeFirstStoreFunctions
         public bool? IsBuiltIn
         {
             get { return _isBuiltIn; }
+        }
+
+        public bool? IsNiladic
+        {
+            get { return _isNiladic; }
         }
     }
 }

--- a/CodeFirstStoreFunctions/FunctionDiscovery.cs
+++ b/CodeFirstStoreFunctions/FunctionDiscovery.cs
@@ -81,7 +81,8 @@ namespace CodeFirstStoreFunctions
                     functionDetailsAttr != null ? functionDetailsAttr.ResultColumnName : null,
                     functionDetailsAttr != null ? functionDetailsAttr.DatabaseSchema : null,
                     storeFunctionKind,
-                    GetBuiltInOption(functionDetailsAttr));
+                    GetBuiltInOption(functionDetailsAttr),
+                    GetNiladicOption(functionDetailsAttr));
             }
 
             return null;
@@ -120,7 +121,7 @@ namespace CodeFirstStoreFunctions
                         throw new InvalidOperationException(
                             string.Format(
                                 "Cannot infer type for parameter '{0}'. All ObjectParameter parameters must be decorated with the ParameterTypeAttribute.",
-                                parameter.Name));    
+                                parameter.Name));
                     }
 
                     parameterType = paramTypeAttribute.Type;
@@ -245,6 +246,13 @@ namespace CodeFirstStoreFunctions
         {
             return (functionDetailsAttribute != null && functionDetailsAttribute.IsBuiltInPropertySet)
                 ? functionDetailsAttribute.IsBuiltIn
+                : (bool?)null;
+        }
+
+        private bool? GetNiladicOption(DbFunctionDetailsAttribute functionDetailsAttribute)
+        {
+            return (functionDetailsAttribute != null && functionDetailsAttribute.IsNiladicPropertySet)
+                ? functionDetailsAttribute.IsNiladic
                 : (bool?)null;
         }
     }

--- a/CodeFirstStoreFunctions/StoreFunctionBuilder.cs
+++ b/CodeFirstStoreFunctions/StoreFunctionBuilder.cs
@@ -55,7 +55,8 @@ namespace CodeFirstStoreFunctions
                     ReturnParameters = CreateFunctionReturnParameters(functionDescriptor),
                     IsComposable = functionDescriptor.StoreFunctionKind != StoreFunctionKind.StoredProcedure,
                     Schema = functionDescriptor.DatabaseSchema ?? _schema,
-                    IsBuiltIn = functionDescriptor.IsBuiltIn
+                    IsBuiltIn = functionDescriptor.IsBuiltIn,
+                    IsNiladic = functionDescriptor.IsNiladic
                 };
 
             return EdmFunction.Create(

--- a/CodeFirstStoreFunctionsTests/E2ETests.cs
+++ b/CodeFirstStoreFunctionsTests/E2ETests.cs
@@ -238,6 +238,13 @@ namespace CodeFirstStoreFunctions
         {
             throw new NotSupportedException();
         }
+
+        [DbFunction("CodeFirstDatabaseSchema", "CURRENT_TIMESTAMP")]
+        [DbFunctionDetails(IsBuiltIn = true, IsNiladic = true)]
+        public static DateTime? CurrentTimestamp()
+        {
+            throw new NotSupportedException();
+        }
     }
 
     #region initializer
@@ -781,6 +788,27 @@ namespace CodeFirstStoreFunctions
             using (var ctx = new MyContext())
             {
                 var q = ctx.Vehicles.Where(v => MyContext.Format(v.ProductionDate, "d", "hu-hu") == "1929. 12. 07.");
+                Assert.Equal(expectedSql, q.ToString());
+                Assert.Equal(1, q.Count());
+            }
+        }
+
+        [Fact]
+        public void Can_invoke_niladic_current_timestamp()
+        {
+            const string expectedSql =
+                @"SELECT 
+    [Limit1].[C1] AS [C1], 
+    [Limit1].[C2] AS [C2]
+    FROM ( SELECT TOP (1) 
+        1 AS [C1], 
+        CURRENT_TIMESTAMP AS [C2]
+        FROM [dbo].[Vehicles] AS [Extent1]
+    )  AS [Limit1]";
+
+            using (var ctx = new MyContext())
+            {
+                var q = ctx.Vehicles.Select(x => new { TimeStamp = MyContext.CurrentTimestamp() }).Take(1);
                 Assert.Equal(expectedSql, q.ToString());
                 Assert.Equal(1, q.Count());
             }

--- a/CodeFirstStoreFunctionsTests/FunctionDescriptorTests.cs
+++ b/CodeFirstStoreFunctionsTests/FunctionDescriptorTests.cs
@@ -21,7 +21,7 @@ namespace CodeFirstStoreFunctions
 
             var functionDescriptor =
                 new FunctionDescriptor("Func", parameters, new EdmType[] { edmType },
-                    "result", "dbo", StoreFunctionKind.TableValuedFunction, isBuiltIn: true);
+                    "result", "dbo", StoreFunctionKind.TableValuedFunction, isBuiltIn: true, isNiladic: false);
 
             Assert.Equal("Func", functionDescriptor.Name);
             Assert.Same(edmType, functionDescriptor.ReturnTypes[0]);

--- a/CodeFirstStoreFunctionsTests/StoreFunctionBuilderTests.cs
+++ b/CodeFirstStoreFunctionsTests/StoreFunctionBuilderTests.cs
@@ -27,7 +27,7 @@ namespace CodeFirstStoreFunctions
                             "p1", PrimitiveType.GetEdmPrimitiveType(PrimitiveTypeKind.String), null, false),
                     },
                     new EdmType[] { PrimitiveType.GetEdmPrimitiveType(PrimitiveTypeKind.Int64) },
-                    "ResultCol", "dbo", StoreFunctionKind.TableValuedFunction, isBuiltIn: null);
+                    "ResultCol", "dbo", StoreFunctionKind.TableValuedFunction, isBuiltIn: null, isNiladic: null);
 
             var storeFunction = new StoreFunctionBuilder(model, "docs", "ns").Create(functionDescriptor);
 
@@ -77,7 +77,8 @@ namespace CodeFirstStoreFunctions
                     "ResultCol",
                     "dbo",
                     StoreFunctionKind.StoredProcedure,
-                    isBuiltIn: null);
+                    isBuiltIn: null,
+                    isNiladic: null);
 
             var storeFunction = new StoreFunctionBuilder(model, "docs", "ns").Create(functionDescriptor);
 
@@ -118,7 +119,8 @@ namespace CodeFirstStoreFunctions
                     "ResultCol",
                     "dbo",
                     StoreFunctionKind.TableValuedFunction,
-                    isBuiltIn: null);
+                    isBuiltIn: null,
+                    isNiladic: null);
 
             var storeFunction = new StoreFunctionBuilder(model, "docs", "ns").Create(functionDescriptor);
 
@@ -152,7 +154,8 @@ namespace CodeFirstStoreFunctions
                     "ResultCol",
                     "dbo",
                     StoreFunctionKind.TableValuedFunction,
-                    isBuiltIn: null);
+                    isBuiltIn: null,
+                    isNiladic: null);
 
             var storeFunction = new StoreFunctionBuilder(model, "docs", "ns").Create(functionDescriptor);
 
@@ -188,7 +191,7 @@ namespace CodeFirstStoreFunctions
                             "p1", PrimitiveType.GetEdmPrimitiveType(PrimitiveTypeKind.String), null, true),
                     },
                     new EdmType[] { PrimitiveType.GetEdmPrimitiveType(PrimitiveTypeKind.Int64) },
-                    "ResultCol", "dbo", StoreFunctionKind.StoredProcedure, isBuiltIn: null);
+                    "ResultCol", "dbo", StoreFunctionKind.StoredProcedure, isBuiltIn: null, isNiladic: null);
 
             var storeFunction = new StoreFunctionBuilder(model, "docs", "ns").Create(functionDescriptor);
 
@@ -211,7 +214,7 @@ namespace CodeFirstStoreFunctions
                     new[]
                     {new ParameterDescriptor("p1", PrimitiveType.GetEdmPrimitiveType(PrimitiveTypeKind.String), null, false)},
                     new EdmType[] { PrimitiveType.GetEdmPrimitiveType(PrimitiveTypeKind.Int64) },
-                    "ResultCol", "dbo", StoreFunctionKind.TableValuedFunction, isBuiltIn: null);
+                    "ResultCol", "dbo", StoreFunctionKind.TableValuedFunction, isBuiltIn: null, isNiladic: null);
 
             var storeFunction = new StoreFunctionBuilder(model, "docs").Create(functionDescriptor);
 
@@ -232,7 +235,7 @@ namespace CodeFirstStoreFunctions
                             "p1", PrimitiveType.GetEdmPrimitiveType(PrimitiveTypeKind.String), "xml", true),
                     },
                     new EdmType[] { PrimitiveType.GetEdmPrimitiveType(PrimitiveTypeKind.Int64) },
-                    "ResultCol", "dbo", StoreFunctionKind.StoredProcedure, isBuiltIn: null);
+                    "ResultCol", "dbo", StoreFunctionKind.StoredProcedure, isBuiltIn: null, isNiladic: null);
 
             var storeFunction = new StoreFunctionBuilder(model, "docs", "ns").Create(functionDescriptor);
 
@@ -255,7 +258,7 @@ namespace CodeFirstStoreFunctions
                             "p1", PrimitiveType.GetEdmPrimitiveType(PrimitiveTypeKind.String), "json", true),
                     },
                     new EdmType[] { PrimitiveType.GetEdmPrimitiveType(PrimitiveTypeKind.Int64) },
-                    "ResultCol", "dbo", StoreFunctionKind.StoredProcedure, isBuiltIn: null);
+                    "ResultCol", "dbo", StoreFunctionKind.StoredProcedure, isBuiltIn: null, isNiladic: null);
 
             Assert.Contains("'json'",
                 Assert.Throws<InvalidOperationException>(() =>
@@ -275,7 +278,7 @@ namespace CodeFirstStoreFunctions
                         "f",
                         new[] { new ParameterDescriptor("p1", PrimitiveType.GetEdmPrimitiveType(PrimitiveTypeKind.String), null, false) },
                         new EdmType[] { PrimitiveType.GetEdmPrimitiveType(PrimitiveTypeKind.Int64) },
-                        "ResultCol", "dbo", StoreFunctionKind.TableValuedFunction, isBuiltIn);
+                        "ResultCol", "dbo", StoreFunctionKind.TableValuedFunction, isBuiltIn, isNiladic: null);
 
                 Assert.Equal(new StoreFunctionBuilder(model, "docs", "ns").Create(functionDescriptor).BuiltInAttribute,
                     isBuiltIn == true);

--- a/CodeFirstStoreFunctionsTests/StoreFunctionBuilderTests.cs
+++ b/CodeFirstStoreFunctionsTests/StoreFunctionBuilderTests.cs
@@ -284,5 +284,25 @@ namespace CodeFirstStoreFunctions
                     isBuiltIn == true);
             }
         }
+
+        [Fact]
+        public void Niladic_attribute_set_correctly()
+        {
+            var model = new DbModelBuilder()
+                .Build(new DbProviderInfo("System.Data.SqlClient", "2012"));
+
+            foreach (var isNiladic in new bool?[] { null, true, false })
+            {
+                var functionDescriptor =
+                    new FunctionDescriptor(
+                        "f",
+                        new[] { new ParameterDescriptor("p1", PrimitiveType.GetEdmPrimitiveType(PrimitiveTypeKind.String), null, false) },
+                        new EdmType[] { PrimitiveType.GetEdmPrimitiveType(PrimitiveTypeKind.Int64) },
+                        "ResultCol", "dbo", StoreFunctionKind.TableValuedFunction, isBuiltIn: null, isNiladic: isNiladic);
+
+                Assert.Equal(new StoreFunctionBuilder(model, "docs", "ns").Create(functionDescriptor).NiladicFunctionAttribute,
+                    isNiladic == true);
+            }
+        }
     }
 }


### PR DESCRIPTION
Allows calling functions without parentheses.

Example:
```
[DbFunction("CodeFirstDatabaseSchema", "CURRENT_TIMESTAMP")]
[CodeFirstStoreFunctions.DbFunctionDetails(IsBuiltIn = true, IsNiladic = true)]
public static DateTime? CurrentTimestamp()
{
      throw new NotSupportedException("Direct calls are not supported.");
}
```